### PR TITLE
Move call of on_disconnect from reconnect because on_disconnect is unrelated to reconnecting

### DIFF
--- a/src/v4/client.rs
+++ b/src/v4/client.rs
@@ -729,12 +729,13 @@ async fn handle_disconnect<T>(
 ) -> Result<(), tokio_tungstenite::tungstenite::Error> {
     // Reuse for dif branches
     let reconnect_client = client.clone();
+
+    (reconnect_client.config.on_disconnect)().await;
+
     let reconnect = move || async move {
         cfg_tracing! {
             tracing::info!("Disconnected from server, attempting to reconnect.");
         }
-
-        (reconnect_client.config.on_disconnect)().await;
 
         loop {
             tokio::time::sleep(Duration::from_millis(


### PR DESCRIPTION
on_disconnect should be called on all handle_disconnect not only if you want to reconnect